### PR TITLE
fix: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
     "minimatch@^3.0.5": "^3.1.5",
     "minimatch@^3.1.1": "^3.1.5",
     "minimatch@^3.1.2": "^3.1.5",
-    "minimatch@^9.0.4": "^9.0.7"
+    "minimatch@^9.0.4": "^9.0.7",
+    "fast-xml-parser": "5.5.7",
+    "flatted": "3.4.2",
+    "brace-expansion@npm:^2.0.1": "2.0.3",
+    "brace-expansion@npm:^2.0.2": "2.0.3",
+    "picomatch@npm:^2.3.1": "2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "minimatch@^3.1.1": "^3.1.5",
     "minimatch@^3.1.2": "^3.1.5",
     "minimatch@^9.0.4": "^9.0.7",
-    "fast-xml-parser": "5.5.7",
-    "flatted": "3.4.2",
-    "brace-expansion@npm:^1.1.7": "1.1.13",
-    "brace-expansion@npm:^2.0.2": "2.0.3",
-    "picomatch": "2.3.2"
+    "fast-xml-parser": "^5.5.7",
+    "flatted": "^3.4.2",
+    "brace-expansion@npm:^1.1.7": "^1.1.13",
+    "brace-expansion@npm:^2.0.2": "^2.0.3",
+    "picomatch": "^2.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "minimatch@^9.0.4": "^9.0.7",
     "fast-xml-parser": "5.5.7",
     "flatted": "3.4.2",
-    "brace-expansion@npm:^2.0.1": "2.0.3",
+    "brace-expansion@npm:^1.1.7": "1.1.13",
     "brace-expansion@npm:^2.0.2": "2.0.3",
-    "picomatch@npm:^2.3.1": "2.3.2"
+    "picomatch": "2.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,6 +1075,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nodable/entities@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@nodable/entities@npm:2.1.0"
+  checksum: ae5a432a665d210bb28b3a9dbe8caf49f46be65fdc626bd14febe8f150b735182efb6967fe12f8c8f39d22e572b8b9361b4915aec094f8cea5e01f683191cf80
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -2175,7 +2182,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.4":
+"fast-xml-builder@npm:^1.1.5":
   version: 1.1.5
   resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
@@ -2184,16 +2191,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:5.5.7":
-  version: 5.5.7
-  resolution: "fast-xml-parser@npm:5.5.7"
+"fast-xml-parser@npm:^5.5.7":
+  version: 5.7.1
+  resolution: "fast-xml-parser@npm:5.7.1"
   dependencies:
-    fast-xml-builder: ^1.1.4
-    path-expression-matcher: ^1.1.3
-    strnum: ^2.2.0
+    "@nodable/entities": ^2.1.0
+    fast-xml-builder: ^1.1.5
+    path-expression-matcher: ^1.5.0
+    strnum: ^2.2.3
   bin:
     fxparser: src/cli/cli.js
-  checksum: decac5d8cd603cb0a1037b632c1a7e267a5420da430ac3420e8a2aee4da7d044553ff80524cda8ed54741fea38202372c84959a52eee61a3a2b61e3233dd5ca5
+  checksum: 863ed69cf556a895231a80ed0091e12671f0d45af336169db55b7cc81c15cd767324469f392df68c5242e80bc416a69394fe69e6287bcb4ef1507875c7b0df84
   languageName: node
   linkType: hard
 
@@ -2273,7 +2281,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:3.4.2":
+"flatted@npm:^3.4.2":
   version: 3.4.2
   resolution: "flatted@npm:3.4.2"
   checksum: 1b2536fccbbf75d67a823dea67819f764c19266ad5e4aca6b47f6bf84d3b5e1c15eb5862f7dec1fb87129b60741524933192051286de52baddbc97129896380d
@@ -3769,6 +3777,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-expression-matcher@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "path-expression-matcher@npm:1.5.0"
+  checksum: 52f0491a88f728f2eefb83a5c4f84f1185a8572e34ba41a72f88e270d5796c966ec1fe78e978599c490ccac0656a4cc55d75485538393873d32a4ef096a8dda6
+  languageName: node
+  linkType: hard
+
 "path-is-absolute@npm:^1.0.0":
   version: 1.0.1
   resolution: "path-is-absolute@npm:1.0.1"
@@ -3814,7 +3829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:2.3.2":
+"picomatch@npm:^2.3.2":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 0a3f5b9ff28faf022e1429b66e47c122e19e7b31cbd098095d29e949684e7ff1d9b83a2133d931326a53ec6ec11c7c59b1850c27fde2f26ca1d5f35861e9701a
@@ -4262,7 +4277,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.2.0":
+"strnum@npm:^2.2.3":
   version: 2.2.3
   resolution: "strnum@npm:2.2.3"
   checksum: e8deb0dd6f40e4a878bdd4404bdfdd47922665fcaaf27f2b345013b30d45d86f4b93d99cbc005bfb7c96edef6173369bd76a9df40bb7758850b7864075a28156

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,21 +1531,21 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.13
+  resolution: "brace-expansion@npm:1.1.13"
   dependencies:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
-  checksum: 12cb6d6310629e3048cadb003e1aca4d8c9bb5c67c3c321bafdd7e7a50155de081f78ea3e0ed92ecc75a9015e784f301efc8132383132f4f7904ad1ac529c562
+  checksum: b5f4329fdbe9d2e25fa250c8f866ebd054ba946179426e99b86dcccddabdb1d481f0e40ee5430032e62a7d0a6c2837605ace6783d015aa1d65d85ca72154d936
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+  version: 2.0.3
+  resolution: "brace-expansion@npm:2.0.3"
   dependencies:
     balanced-match: ^1.0.0
-  checksum: 01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
+  checksum: e9dd66caaf0784126e1654f1bc19adb28f3ef86f39f2226f833f7700ec727c141f6cd85eaa47bacf3426beda01c9fbc3a2f28174cf59330dc9b58ffaf9e09d96
   languageName: node
   linkType: hard
 
@@ -3814,10 +3814,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "picomatch@npm:2.3.1"
-  checksum: 050c865ce81119c4822c45d3c84f1ced46f93a0126febae20737bd05ca20589c564d6e9226977df859ed5e03dc73f02584a2b0faad36e896936238238b0446cf
+"picomatch@npm:2.3.2":
+  version: 2.3.2
+  resolution: "picomatch@npm:2.3.2"
+  checksum: 0a3f5b9ff28faf022e1429b66e47c122e19e7b31cbd098095d29e949684e7ff1d9b83a2133d931326a53ec6ec11c7c59b1850c27fde2f26ca1d5f35861e9701a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,25 +2175,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "fast-xml-builder@npm:1.1.3"
+"fast-xml-builder@npm:^1.1.4":
+  version: 1.1.5
+  resolution: "fast-xml-builder@npm:1.1.5"
   dependencies:
     path-expression-matcher: ^1.1.3
-  checksum: fca50dc49c6aa1963403b99483cf6088cff900c82e16f13a730f6f1a60a3a4d724a005dc634448aaf84e0733e4a4b961658f4004e62ab0415f5ddc73b05e6eb7
+  checksum: 02ea4ea959ed985033895a2000555c22f91f93e30376f7e11ee384f3839f5af3c97a8a646e4d6ba585a9b42e949b13ec89ce8bda061ee48b32a1b49f1c713372
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^5.0.7":
-  version: 5.5.5
-  resolution: "fast-xml-parser@npm:5.5.5"
+"fast-xml-parser@npm:5.5.7":
+  version: 5.5.7
+  resolution: "fast-xml-parser@npm:5.5.7"
   dependencies:
-    fast-xml-builder: ^1.1.3
+    fast-xml-builder: ^1.1.4
     path-expression-matcher: ^1.1.3
-    strnum: ^2.1.2
+    strnum: ^2.2.0
   bin:
     fxparser: src/cli/cli.js
-  checksum: 076643a1bcc3d46388bf2b98b0097a223b5f43e8dfc9b98913d6b80521f39b487419a0d644f4037814dc2806abdd52f057215df1f9653608a839065cb05bccca
+  checksum: decac5d8cd603cb0a1037b632c1a7e267a5420da430ac3420e8a2aee4da7d044553ff80524cda8ed54741fea38202372c84959a52eee61a3a2b61e3233dd5ca5
   languageName: node
   linkType: hard
 
@@ -2273,10 +2273,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9":
-  version: 3.2.9
-  resolution: "flatted@npm:3.2.9"
-  checksum: f14167fbe26a9d20f6fca8d998e8f1f41df72c8e81f9f2c9d61ed2bea058248f5e1cbd05e7f88c0e5087a6a0b822a1e5e2b446e879f3cfbe0b07ba2d7f80b026
+"flatted@npm:3.4.2":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 1b2536fccbbf75d67a823dea67819f764c19266ad5e4aca6b47f6bf84d3b5e1c15eb5862f7dec1fb87129b60741524933192051286de52baddbc97129896380d
   languageName: node
   linkType: hard
 
@@ -4262,10 +4262,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strnum@npm:^2.1.2":
-  version: 2.2.0
-  resolution: "strnum@npm:2.2.0"
-  checksum: cf9fda01ab16e1295db16a8f62b852fd92f3ed9ef940b4326a0053e3e658e7b35de82c2cac6ad946dcf6b6044d4d804845baae4659f7afcb4cdc3dcf2870d152
+"strnum@npm:^2.2.0":
+  version: 2.2.3
+  resolution: "strnum@npm:2.2.3"
+  checksum: e8deb0dd6f40e4a878bdd4404bdfdd47922665fcaaf27f2b345013b30d45d86f4b93d99cbc005bfb7c96edef6173369bd76a9df40bb7758850b7864075a28156
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolved 5 open Dependabot security alerts by bumping vulnerable transitive dependencies via yarn resolutions.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #71 | `fast-xml-parser` | **high** | Pinned to 5.5.7 via yarn resolution |
| #75 | `fast-xml-parser` | **medium** | Pinned to 5.5.7 via yarn resolution |
| #70 | `flatted` | **high** | Pinned to 3.4.2 via yarn resolution |
| #74 | `brace-expansion` | **medium** | Pinned to 2.0.3 via yarn resolution |
| #72 | `picomatch` | **medium** | Pinned to 2.3.2 via yarn resolution |